### PR TITLE
Remove obsolete property

### DIFF
--- a/UnityEngine.UI/EventSystem/InputModules/StandaloneInputModule.cs
+++ b/UnityEngine.UI/EventSystem/InputModules/StandaloneInputModule.cs
@@ -131,8 +131,6 @@ namespace UnityEngine.EventSystems
 
             var toSelect = eventSystem.currentSelectedGameObject;
             if (toSelect == null)
-                toSelect = eventSystem.lastSelectedGameObject;
-            if (toSelect == null)
                 toSelect = eventSystem.firstSelectedGameObject;
 
             eventSystem.SetSelectedGameObject(toSelect, GetBaseEventData());


### PR DESCRIPTION
The EventSystem property lastSelectedGameObject is obsolete and no longer supported.